### PR TITLE
Fix the FlurryTumblrAPI dependency

### DIFF
--- a/Flurry-iOS-SDK.podspec
+++ b/Flurry-iOS-SDK.podspec
@@ -65,6 +65,7 @@ Pod::Spec.new do |s|
     ]
 
     ss.dependency 'Flurry-iOS-SDK/FlurrySDK'
+    ss.dependency 'Flurry-iOS-SDK/FlurryAds'
   end
 
   s.resource_bundles = {


### PR DESCRIPTION
The FlurryTumblrAPI depends on FlurryAds, so it should be listed as an
explicit dependency

This commit is to address issue #7 