### PR TITLE
added -all_load linker flag to FlurryAds subspec

### DIFF
--- a/Flurry-iOS-SDK.podspec
+++ b/Flurry-iOS-SDK.podspec
@@ -71,6 +71,7 @@ Pod::Spec.new do |s|
     ss.weak_frameworks = 'AdSupport', 'StoreKit'
     ss.vendored_libraries = "FlurryAds/libFlurryAds_7.5.0.a" 
     ss.dependency 'Flurry-iOS-SDK/FlurrySDK'
+    ss.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-all_load' }
   end
   
   s.subspec 'TumblrAPI' do |ss|

--- a/Flurry-iOS-SDK.podspec
+++ b/Flurry-iOS-SDK.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Flurry-iOS-SDK'
-  s.version          = '7.5.0'
+  s.version          = '7.5.1'
   s.summary          = 'Flurry SDK for iOS'
   s.license          = { :type => 'Commercial', :file => 'Licenses/Flurry-LICENSE.txt' }
   s.description      = 'FlurrySDK consists of: Flurry for analytics tracking and reporting. Flurry Ads for Native, Full Screen Ads integration'


### PR DESCRIPTION
this is needed when you have use_frameworks! in the Podfile and use FlurryAds subspec.  without this flag certain symbols will be stripped, f.e. FlurryAds static API.  see issue #18 
